### PR TITLE
fix: dflydev/dot-access-data does not support php8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/var-exporter": "^5.2",
         "symfony/console": "^4.3",
         "vlucas/phpdotenv": "^2.4",
-        "dflydev/dot-access-data": "^2.0",
+        "dflydev/dot-access-data": "^3.0",
         "maximebf/debugbar": "^1.15",
         "phpmailer/phpmailer": "^6.0",
         "twig/twig": "^2.7",


### PR DESCRIPTION
- The dflydev/dot-access-data version 2.0 does not work on php8.0
- I suggest to upgrade to version 3.0 which can work on php7.0 and php8.0